### PR TITLE
Deleting target folder before post build event, Issue 4

### DIFF
--- a/GroundSnake/GroundSnake.csproj
+++ b/GroundSnake/GroundSnake.csproj
@@ -110,7 +110,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Autodesk\ApplicationPlugins\GroundSnake.bundle\Contents"
+    <PostBuildEvent>RD /S /Q "C:\Users\$(Username)\AppData\Roaming\Autodesk\ApplicationPlugins\GroundSnake.bundle"
+
+call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Autodesk\ApplicationPlugins\GroundSnake.bundle\Contents"
 
 C:\Windows\System32\xcopy "$(ProjectDir)PluginFile\PackageContents.xml" "C:\Users\$(Username)\AppData\Roaming\Autodesk\ApplicationPlugins\GroundSnake.bundle"
 </PostBuildEvent>


### PR DESCRIPTION
Fixes #4 

Deletes the target folder before UI_PostBuildEvent is called.

Something is topping the copying of files if it allready exists