### PR TITLE
Fixes #7, copy local false for one dll

### DIFF
--- a/Adapter_GroundSnake/Adapter_GroundSnake.csproj
+++ b/Adapter_GroundSnake/Adapter_GroundSnake.csproj
@@ -45,6 +45,7 @@
     </Reference>
     <Reference Include="AecBaseMgd">
       <HintPath>..\..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2017\AecBaseMgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="AeccDbMgd">
       <HintPath>..\..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2017\C3D\AeccDbMgd.dll</HintPath>


### PR DESCRIPTION
Copy local was set to true for one file in one project, causing dynamo toolkit not to load at all with this compiled.  <3 Autodesk.

