### PR TITLE
Align to changes in BHoM Adapter and remove UpdateProperty

### DIFF
--- a/Adapter_GroundSnake/Create/_Create.cs
+++ b/Adapter_GroundSnake/Create/_Create.cs
@@ -20,7 +20,7 @@ namespace BH.UI.Civil.Adapter
         /***************************************************/
 
         //General method called by the adapter for push
-        protected override bool Create<T>(IEnumerable<T> objects, bool replaceAll = false)
+        protected override bool Create<T>(IEnumerable<T> objects)
         {
             return CreateCollection(objects as dynamic);
         }

--- a/Civil3D_Adapter/Civil3DAdapter.cs
+++ b/Civil3D_Adapter/Civil3DAdapter.cs
@@ -86,7 +86,6 @@ namespace BH.Adapter.Civil3D
             //Reset the wait event
             m_waitEvent.Reset();
 
-
             if (!CheckConnection())
                 return new List<object>();
 
@@ -115,50 +114,6 @@ namespace BH.Adapter.Civil3D
             return returnObjs;
 
         }
-
-        /***************************************************/
-
-        public override int Delete(FilterRequest filter, Dictionary<string, object> config = null)
-        {
-
-            throw new NotImplementedException();
-        }
-
-        /***************************************************/
-
-        public override int UpdateProperty(FilterRequest filter, string property, object newValue, Dictionary<string, object> config = null)
-        {
-            //Reset the wait event
-            m_waitEvent.Reset();
-
-
-            if (!CheckConnection())
-                return 0;
-
-            config = config == null ? new Dictionary<string, object>() : null;
-
-            //Send data through the socket link
-            m_linkIn.SendData(new List<object>() { PackageType.UpdateProperty, new Tuple<FilterRequest, string, object>(filter, property, newValue), config, Civil3DSettings });
-
-            //Wait until the return message has been recieved
-            if (!m_waitEvent.WaitOne(TimeSpan.FromMinutes(m_waitTime)))
-                TimeOutError();
-
-            int returnValue = 0;
-            //Grab the return objects from the latest package
-            if (m_returnPackage.Count > 0 && m_returnPackage[0] is int)
-                returnValue = (int)m_returnPackage[0];
-
-            //Clear the return list
-            m_returnPackage.Clear();
-
-            //Raise returned events
-            RaiseEvents();
-
-            //Return the package
-            return returnValue;
-        }
-
 
         /***************************************************/
         /**** Private  Fields                           ****/
@@ -230,7 +185,7 @@ namespace BH.Adapter.Civil3D
         /**** Protected  Methods                        ****/
         /***************************************************/
 
-        protected override bool Create<T>(IEnumerable<T> objects, bool replaceAll = false)
+        protected override bool Create<T>(IEnumerable<T> objects)
         {
             throw new NotImplementedException();
         }

--- a/GroundSnake/BHoMListener.cs
+++ b/GroundSnake/BHoMListener.cs
@@ -121,11 +121,6 @@ namespace BH.UI.Civil
                             IRequest request = package.Data[1] as IRequest;
                             ReturnData(m_adapter.Pull(request, config));
                             break;
-                        case PackageType.UpdateProperty:
-                            if (!CheckPackageSize(package)) return;
-                            var tuple = package.Data[1] as Tuple<FilterRequest, string, object>;
-                            ReturnData(new List<object> { m_adapter.UpdateProperty(tuple.Item1, tuple.Item2, tuple.Item3) });
-                            break;
                         default:
                             ReturnData(new List<string> { "Unrecognized package type" });
                             return;


### PR DESCRIPTION
### NOTE: Depends on 
https://github.com/BHoM/BHoM_Adapter/pull/151
https://github.com/BHoM/BHoM_UI/pull/149

   - If testing on Grasshopper, you need [Grasshopper_Toolkit branch](https://github.com/BHoM/Grasshopper_Toolkit)
   - If testing on Dynamo, you need [Dynamo_Toolkit branch](https://github.com/BHoM/Dynamo_Toolkit/pull/178)
   - If testing on Excel_Toolkit, you need [Excel_Toolkit branch](https://github.com/BHoM/Excel_Toolkit/pull/163)

   - If your Toolkit uses Socket_Toolkit: [Socket_Toolkit branch](https://github.com/BHoM/Socket_Toolkit/tree/BHoM_Adapter-refactoringLvl3-01)
   - If your Toolkit uses Mongo_Toolkit: [Mongo_Toolkit branch](https://github.com/BHoM/Mongo_Toolkit/tree/BHoM_Adapter-refactoringLvl3-01)

 ### Issues addressed by this PR

 Closes #51 


Updating adapter to align with changes in the parent BHoMAdapter

 ### Test files
<!-- Link to test files to validate the proposed changes -->

All previous scripts should still be working as before.
