### PR TITLE
Setting copy local to false for all AutoDesk and BHoM dlls

### DIFF
--- a/Adapter_Civil_UI/Adapter_Civil_UI.csproj
+++ b/Adapter_Civil_UI/Adapter_Civil_UI.csproj
@@ -51,12 +51,15 @@
   <ItemGroup>
     <Reference Include="accoremgd">
       <HintPath>..\libs\accoremgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="acdbmgd">
       <HintPath>..\libs\acdbmgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="acmgd">
       <HintPath>..\libs\acmgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Adapter_Engine">
       <HintPath>..\..\BHoM_Adapter\Build\Adapter_Engine.dll</HintPath>
@@ -68,9 +71,11 @@
     </Reference>
     <Reference Include="AecBaseMgd">
       <HintPath>..\libs\AecBaseMgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="AeccDbMgd">
       <HintPath>..\libs\AeccDbMgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
@@ -82,6 +87,7 @@
     </Reference>
     <Reference Include="Geometry_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Geometry_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Civil3D_Adapter/Civil3D_Adapter.csproj
+++ b/Civil3D_Adapter/Civil3D_Adapter.csproj
@@ -51,9 +51,11 @@
   <ItemGroup>
     <Reference Include="Adapter_Engine">
       <HintPath>..\..\BHoM_Adapter\Build\Adapter_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Adapter_oM">
       <HintPath>..\..\BHoM_Adapter\Build\Adapter_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>

--- a/Civil3D_Engine/Civil3D_Engine.csproj
+++ b/Civil3D_Engine/Civil3D_Engine.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Dimensional_oM">
       <HintPath>..\..\BHoM\Build\Dimensional_oM.dll</HintPath>

--- a/Civil_UI/Civil_UI.csproj
+++ b/Civil_UI/Civil_UI.csproj
@@ -52,30 +52,37 @@
     <Reference Include="accoremgd, Version=23.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\accoremgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="acdbmgd, Version=23.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\acdbmgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="acmgd, Version=23.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\acmgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Adapter_Engine, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_Adapter\Build\Adapter_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Adapter_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_Adapter\Build\Adapter_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="AecBaseMgd, Version=8.1.48.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\AecBaseMgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="AeccDbMgd, Version=13.0.1175.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\AeccDbMgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
@@ -134,6 +141,7 @@
     <ProjectReference Include="..\Adapter_Civil_UI\Adapter_Civil_UI.csproj">
       <Project>{5c152ab4-4111-48ff-b2d6-b9a557325595}</Project>
       <Name>Adapter_Civil_UI</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Civil3D_Adapter\Civil3D_Adapter.csproj">
       <Project>{b5bddda4-e87f-4e4e-80a7-10b1e29af4fa}</Project>
@@ -153,6 +161,7 @@
     <ProjectReference Include="..\Engine_Civil_UI\Engine_Civil_UI.csproj">
       <Project>{901ba0a8-a324-435a-b5d4-a400f5bbafaf}</Project>
       <Name>Engine_Civil_UI</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Engine_Civil_UI/Engine_Civil_UI.csproj
+++ b/Engine_Civil_UI/Engine_Civil_UI.csproj
@@ -51,18 +51,23 @@
   <ItemGroup>
     <Reference Include="accoremgd">
       <HintPath>..\libs\accoremgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="acdbmgd">
       <HintPath>..\libs\acdbmgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="acmgd">
       <HintPath>..\libs\acmgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="AecBaseMgd">
       <HintPath>..\libs\AecBaseMgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="AeccDbMgd">
       <HintPath>..\libs\AeccDbMgd.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
@@ -86,6 +91,7 @@
     </Reference>
     <Reference Include="Reflection_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #73 

<!-- Add short description of what has been fixed -->
Setting copy local to false for all Autodesk dlls.  having them copied over make dynamo not load up.

While at it, also set copy local false for all BHoM dlls to follow compliance

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->