### PR TITLE
Remove dependency to UI_PostBuild

### DIFF
--- a/Civil_UI/Civil_UI.csproj
+++ b/Civil_UI/Civil_UI.csproj
@@ -128,10 +128,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UI_PostBuild">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\UI_PostBuild.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CivilListener.cs" />


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #83

Simply removes the reference to UI_PostBuild. No additional action needed given that UI_PostBuild isn't actually used anywhere in this repo.

### Test files
Just make sure this still compiles

