### PR TITLE
Remove reference to AdapterIdName in the constructor

### DIFF
--- a/Adapter_Civil_UI/Civil3DAdapter.cs
+++ b/Adapter_Civil_UI/Civil3DAdapter.cs
@@ -18,7 +18,6 @@ namespace BH.UI.Civil.Adapter
 
         public CivilUIAdapter()
         {
-            AdapterIdName = "Civil3D_Adapter";
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateOnly;
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #92 

<!-- Add short description of what has been fixed -->

Removing reference to AdapterNameId being removed in https://github.com/BHoM/BHoM_Adapter/pull/263

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->